### PR TITLE
Changed: Makefile for adding new targets for development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: go
 matrix:
   include:
     - go: "1.11.x"
-      env: GO111MODULE=on LINT=true
+      env: GO111MODULE=on LINT=true COVERAGE=true
     - go: "1.10.x"
     - go: "1.9.x"
     - go: "1.8.x"
@@ -15,10 +15,6 @@ matrix:
       env: GO111MODULE=on
 
 before_install:
-  # setup some env vars
-  - GO_FILES=$(find . -iname '*.go' | grep -v /vendor/)  # All the .go files, excluding vendor/
-  - PKGS=$(go list ./... | grep -v /vendor/)             # All the import paths, excluding vendor/
-
   # Install CI tools
   - make .go-tools-install-ci
 
@@ -26,10 +22,9 @@ before_install:
   - go get -u github.com/mattn/goveralls
 
 script:
-  - test -z $(gofmt -s -l $GO_FILES)  # Fail if a .go file hasn't been formatted with gofmt
   - if [ "$LINT" = true ]; then make lint; fi
-  - go test -v -covermode=count -coverprofile=profile.cov $PKGS
-  - goveralls -coverprofile=profile.cov -service=travis-ci
+  - if [ "$COVERAGE" = true ]; then make test TARGS="-v -covermode=count -coverprofile=profile.cov"; else make test TARGS="-v";  fi
+  - if [ "$COVERAGE" = true ]; then goveralls -coverprofile=profile.cov -service=travis-ci; fi
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -8,18 +8,26 @@ endef
 
 export HELP_MSG
 
-
 .PHONY: help
 help: ## Show this help
 	@echo "$$HELP_MSG"
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/:.*##/:##/' | column -t -s '##'
 
-.PHONY: go-tools-install
-go-tools-install: .gti-golangci-lint ## Install Go tools
-
 .PHONY: lint
 lint: ## Lint the code
 	@$(GOLANGCI_LINT_BIN) run --enable-all --exclude-use-default=false
+
+.PHONY: test
+test: ## Execute the tests
+	@go test $(TARGS) ./...
+
+.PHONY: ci
+ci: ## Simulate the same checks that the CI runs
+	@make lint
+	@make test
+
+.PHONY: go-tools-install
+go-tools-install: .gti-golangci-lint ## Install Go tools
 
 .PHONY: .go-tools-install-ci
 .go-tools-install-ci: .gti-golangci-lint


### PR DESCRIPTION
Added new Makefile targets for allowing to run in similar way, in local, what the CI runs.

There are also some changes in the CI configuration for using as much as possible the Makefile targets rather than having those instructions in the same CI configuration and only enabling test coverage when the CI runs with the current stable Go version (1.11).